### PR TITLE
fix: remove the extra ` before Horizontal infrared radiation

### DIFF
--- a/my_project/global_scheme.py
+++ b/my_project/global_scheme.py
@@ -198,7 +198,7 @@ name_dict = {
     "Apressure_name": "Atmospheric pressure",
     # Radiation
     "EHrad_name": "Extraterrestrial horizontal irradiation",
-    "HIRrad_name": "´Horizontal infrared radiation",
+    "HIRrad_name": "Horizontal infrared radiation",
     "GHrad_name": "Global horizontal radiation",
     "DNrad_name": "Direct normal radiation",
     "DifHrad_name": "Diffuse horizontal radiation",


### PR DESCRIPTION
Nothing major here! I was playing around with the app and noticed the extra ` - This change should fix it.

![image](https://user-images.githubusercontent.com/2915573/146025638-08bbf771-a6ce-4b45-9fce-dacc2c88b426.png)