### PR TITLE
#183 Inconsistent filtering behaviour in Outdoor comfort tab (1/2) 

### DIFF
--- a/my_project/tab_outdoor_comfort/app_outdoor_comfort.py
+++ b/my_project/tab_outdoor_comfort/app_outdoor_comfort.py
@@ -127,34 +127,13 @@ def layout_outdoor_comfort():
                 ],
             ),
             html.Div(id="outdoor-comfort-output"),
-            html.Div(
-                children=title_with_tooltip(
-                    text="UTCI heatmap chart",
-                    tooltip_text=None,
-                    id_button="utci-charts-label",
-                )
-            ),
             dcc.Loading(
                 html.Div(id="utci-heatmap"),
                 type="circle",
             ),
-            html.Div(
-                children=title_with_tooltip(
-                    text="UTCI thermal stress chart",
-                    tooltip_text=None,
-                    id_button="utci-charts-label",
-                )
-            ),
             dcc.Loading(
                 html.Div(id="utci-category-heatmap"),
                 type="circle",
-            ),
-            html.Div(
-                children=title_with_tooltip(
-                    text="UTCI thermal stress distribution chart",
-                    tooltip_text=None,
-                    id_button="utci-charts-label",
-                )
             ),
             dcc.Loading(
                 html.Div(id="utci-summary-chart"),
@@ -220,7 +199,7 @@ def update_tab_utci_value(ts, var, global_local, time_filter, df, meta, si_ip, m
     units = generate_units_degree(si_ip)
     return dcc.Graph(
         config=generate_chart_name("heatmap", meta, custom_inputs, units),
-        figure=heatmap_with_filter(df, var, global_local, si_ip, time_filter, month, hour, invert_month, invert_hour)
+        figure=heatmap_with_filter(df, var, global_local, si_ip, time_filter, month, hour, invert_month, invert_hour, "UTCI heatmap")
     )
 
 
@@ -260,7 +239,7 @@ def change_image_based_on_selection(value):
     ],
 )
 def update_tab_utci_category(ts, var, global_local, time_filter, df, meta, si_ip, month, hour, invert_month, invert_hour):
-    utci_stress_cat = heatmap_with_filter(df, var + "_categories", global_local, si_ip, time_filter, month, hour, invert_month, invert_hour)
+    utci_stress_cat = heatmap_with_filter(df, var + "_categories", global_local, si_ip, time_filter, month, hour, invert_month, invert_hour, "UTCI thermal stress")
     utci_stress_cat["data"][0]["colorbar"] = dict(
         title="Thermal stress",
         titleside="top",
@@ -317,15 +296,7 @@ def update_tab_utci_summary_chart(
         invert_hour,
         si_ip
 ):
-    utci_summary_chart = thermal_stress_stacked_barchart(df, var + "_categories", time_filter, month, hour, invert_month, invert_hour)
-    utci_summary_chart = utci_summary_chart.update_layout(
-        margin=tight_margins,
-        title="",
-        legend=dict(orientation="h", yanchor="bottom", y=1.05, xanchor="right", x=1),
-    )
-    utci_summary_chart.update_xaxes(
-        dict(tickmode="array", tickvals=np.arange(0, 12, 1), ticktext=month_lst)
-    )
+    utci_summary_chart = thermal_stress_stacked_barchart(df, var + "_categories", time_filter, month, hour, invert_month, invert_hour, "UTCI thermal stress distribution")
     custom_inputs = f"{var}"
     units = generate_units(si_ip)
     return dcc.Graph(

--- a/my_project/template_graphs.py
+++ b/my_project/template_graphs.py
@@ -11,7 +11,7 @@ from .global_scheme import month_lst, template, tight_margins
 
 
 # violin template
-from .utils import code_timer
+from .utils import code_timer, determine_month_and_hour_filter
 
 
 def violin(df, var, global_local, si_ip):
@@ -319,15 +319,19 @@ def daily_profile(df, var, global_local, si_ip):
 
 # @code_timer
 def heatmap_with_filter(
-    df, var, global_local, si_ip, time_filter, month, hour, invert_month, invert_hour
+    df, var, global_local, si_ip, time_filter, month, hour, invert_month, invert_hour, title
 ):
     """General function that returns a heatmap."""
     var_unit = mapping_dictionary[var][si_ip]["unit"]
     var_range = mapping_dictionary[var][si_ip]["range"]
     var_color = mapping_dictionary[var]["color"]
 
-    df, start_month, end_month = filter_df_by_month_and_hour(
+    df = filter_df_by_month_and_hour(
         df, time_filter, month, hour, invert_month, invert_hour, var
+    )
+
+    start_month, end_month, start_hour, end_hour = determine_month_and_hour_filter(
+        month, hour, invert_month, invert_hour
     )
 
     if df.dropna(subset=["month"]).shape[0] == 0:
@@ -375,7 +379,13 @@ def heatmap_with_filter(
     fig.update_yaxes(title_text="Hour")
     fig.update_xaxes(title_text="Day")
 
-    fig.update_layout(template=template, margin=tight_margins, yaxis_nticks=13)
+    if time_filter:
+        title += (
+            f" between the months of {month_lst[start_month - 1]} and "
+            f"{month_lst[end_month - 1]}<br>and between the hours {start_hour}"
+            f":00 and {end_hour}:00"
+        )
+    fig.update_layout(template=template, title=title, margin=tight_margins.copy().update({"t": 55}), yaxis_nticks=13)
     fig.update_xaxes(showline=True, linewidth=1, linecolor="black", mirror=True)
     fig.update_yaxes(showline=True, linewidth=1, linecolor="black", mirror=True)
 
@@ -554,7 +564,7 @@ def convert_bins(sbins):
 
 
 def thermal_stress_stacked_barchart(
-    df, var, time_filter, month, hour, invert_month, invert_hour
+    df, var, time_filter, month, hour, invert_month, invert_hour, title
 ):
     """Return the summary bar chart."""
     categories = [
@@ -582,8 +592,12 @@ def thermal_stress_stacked_barchart(
         "#6B1F18",
     ]
 
-    df, start_month, end_month = filter_df_by_month_and_hour(
+    df = filter_df_by_month_and_hour(
         df, time_filter, month, hour, invert_month, invert_hour, var
+    )
+
+    start_month, end_month, start_hour, end_hour = determine_month_and_hour_filter(
+        month, hour, invert_month, invert_hour
     )
 
     if df.dropna(subset=["month"]).shape[0] == 0:
@@ -614,10 +628,9 @@ def thermal_stress_stacked_barchart(
             return 0
 
     for i in range(len(categories)):
-        x_data = list(range(start_month - 1, end_month + 1))
+        x_data = list(range(0, 12))
         y_data = [
-            catch(lambda: new_df.iloc[idx][categories[i]])
-            for idx in range(0, end_month - start_month + 1)
+            catch(lambda: new_df.iloc[mth][categories[i]]) for mth in range(0, 12)
         ]
         data.append(
             go.Bar(
@@ -634,13 +647,27 @@ def thermal_stress_stacked_barchart(
             )
         )
 
+    if time_filter:
+        title += (
+            f" between the months of {month_lst[start_month - 1]} and "
+            f"{month_lst[end_month - 1]} and between the hours {start_hour}"
+            f":00 and {end_hour}:00"
+        )
+
     fig = go.Figure(data=data)
-    fig.update_layout(barmode="stack", dragmode=False)
-
-    fig.update_yaxes(title_text="Percentage (%)")
-    fig.update_xaxes(title_text="Day")
-    fig.update_layout(barnorm="percent")
-
+    fig.update_layout(legend=dict(orientation="h", yanchor="bottom", y=1.05, xanchor="right", x=1),
+                      barmode="stack",
+                      dragmode=False,
+                      title=title,
+                      barnorm="percent",
+                      margin=tight_margins.copy().update({"t": 65}))
+    fig.update_yaxes(title_text="Percentage (%)", showline=True, linewidth=1, linecolor="black", mirror=True)
+    fig.update_xaxes(dict(tickmode="array", tickvals=np.arange(0, 12, 1), ticktext=month_lst),
+                     title_text="Day",
+                     showline=True,
+                     linewidth=1,
+                     linecolor="black",
+                     mirror=True)
     return fig
 
 
@@ -795,7 +822,4 @@ def filter_df_by_month_and_hour(
             mask = (df["hour"] >= end_hour) & (df["hour"] <= start_hour)
             df.loc[mask, var] = None
 
-    start_month = int(df.iloc[0]["month"])
-    end_month = int(df.iloc[-1]["month"])
-
-    return df, start_month, end_month
+    return df

--- a/my_project/template_graphs.py
+++ b/my_project/template_graphs.py
@@ -327,7 +327,7 @@ def heatmap_with_filter(
     var_color = mapping_dictionary[var]["color"]
 
     df, start_month, end_month = filter_df_by_month_and_hour(
-        df, time_filter, month, hour, invert_month, invert_hour
+        df, time_filter, month, hour, invert_month, invert_hour, var
     )
 
     if df.dropna(subset=["month"]).shape[0] == 0:
@@ -583,7 +583,7 @@ def thermal_stress_stacked_barchart(
     ]
 
     df, start_month, end_month = filter_df_by_month_and_hour(
-        df, time_filter, month, hour, invert_month, invert_hour
+        df, time_filter, month, hour, invert_month, invert_hour, var
     )
 
     if df.dropna(subset=["month"]).shape[0] == 0:
@@ -765,7 +765,7 @@ def barchart(df, var, time_filter_info, data_filter_info, normalize, si_ip):
 
 
 def filter_df_by_month_and_hour(
-    df, time_filter, month, hour, invert_month, invert_hour
+    df, time_filter, month, hour, invert_month, invert_hour, var
 ):
     start_month, end_month = month
     if invert_month == ["invert"] and (start_month != 1 or end_month != 12):
@@ -783,19 +783,18 @@ def filter_df_by_month_and_hour(
     if time_filter:
         if start_month <= end_month:
             mask = (df["month"] < start_month) | (df["month"] > end_month)
-            df[mask] = None
+            df.loc[mask, var] = None
         else:
             mask = (df["month"] >= end_month) & (df["month"] <= start_month)
-            df[mask] = None
+            df.loc[mask, var] = None
 
         if start_hour <= end_hour:
             mask = (df["hour"] < start_hour) | (df["hour"] > end_hour)
-            df[mask] = None
+            df.loc[mask, var] = None
         else:
             mask = (df["hour"] >= end_hour) & (df["hour"] <= start_hour)
-            df[mask] = None
+            df.loc[mask, var] = None
 
-    df.dropna(inplace=True)
     start_month = int(df.iloc[0]["month"])
     end_month = int(df.iloc[-1]["month"])
 


### PR DESCRIPTION
# What I have done
I made some changes to the UI of the outdoor comfort tab:
- Per requested, each chart now has a title displaying its name and the current filter.
- All months are shown, but only with filtered data
- Thermal stress distribution chart's appearance is more consistent with other charts.

# Unexpected change: 
In other charts, the title is broken down into two lines. But for thermal stress distribution chart, I have to make its title one-line, otherwise it will overlap the legend. 

I know that I could increase the `t` in this code `margin=tight_margins.copy().update({"t": 65}))` on line 663, `my_project/template_graphs.py`, but it didn't work. 
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/02c17b6f-3359-4d8a-8f27-4ef87540f8a9)


# Future issue:
This is an existing issues on all the chart with dynamic title with fitlers. The titles are not displaying the filtered values correctly. Consider these cases:

<hr>

No filter on _hour-range_:
**=> Title should be "... between 0:00 and 24:00"**
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/d1f52881-f251-4862-b8ce-480de239cda7)

<hr>


_Month-range_ and _slide-range_ with one point at either extreme end (Jan/Dec, 0/24). Invert is checked. 
**=> The title should display the months/hours range that are not in the fitler**
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/4f0940f5-ef7d-494e-ad0b-c62990a6dd62)

<hr>

_Month-range_ and _slide-range_ with no point at either extreme end (Jan/Dec, 0/24). Invert is checked. 
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/9ef59413-526d-438d-aaff-700849ee821c)
**=> The title should display the broken month/hours ranges that are not in the fitler**



