### PR TITLE
[Need clarification] #184 Inconsistent filtering behaviour in Outdoor comfort tab (2/2)

### DIFF
--- a/my_project/tab_outdoor_comfort/app_outdoor_comfort.py
+++ b/my_project/tab_outdoor_comfort/app_outdoor_comfort.py
@@ -10,7 +10,7 @@ from my_project.template_graphs import (
     heatmap_with_filter,
     thermal_stress_stacked_barchart,
 )
-from my_project.utils import generate_chart_name, generate_units_degree, generate_units
+from my_project.utils import generate_chart_name, generate_units_degree, generate_units, title_with_tooltip
 import numpy as np
 from app import app
 
@@ -136,6 +136,34 @@ def layout_outdoor_comfort():
             dcc.Loading(
                 html.Div(id="utci-category-heatmap"),
                 type="circle",
+            ),
+            html.Div(
+                className="container-row align-center justify-center",
+                children=[
+                    dbc.Checklist(
+                        options=[
+                            {"label": "", "value": 1},
+                        ],
+                        value=[1],
+                        id="outdoor-comfort-switches-input",
+                        switch=True,
+                        style={
+                            "padding": "1rem",
+                            "marginTop": "1rem",
+                            "marginRight": "-2rem",
+                        },
+                    ),
+                    html.Div(
+                        children=title_with_tooltip(
+                            text="Normalize data",
+                            tooltip_text=(
+                                "If normalized is enabled it calculates the % "
+                                "time otherwise it calculates the total number of hours"
+                            ),
+                            id_button="outdoor-comfort-normalize",
+                        ),
+                    ),
+                ],
             ),
             dcc.Loading(
                 html.Div(id="utci-summary-chart"),
@@ -319,6 +347,7 @@ def update_tab_utci_category(
     [
         Input("tab7-dropdown", "value"),
         Input("month-hour-filter-outdoor-comfort", "n_clicks"),
+        Input("outdoor-comfort-switches-input", "value"),
     ],
     [
         State("df-store", "data"),
@@ -331,7 +360,7 @@ def update_tab_utci_category(
     ],
 )
 def update_tab_utci_summary_chart(
-    var, time_filter, df, month, hour, meta, invert_month, invert_hour, si_ip
+    var, time_filter, normalize, df, month, hour, meta, invert_month, invert_hour, si_ip
 ):
     utci_summary_chart = thermal_stress_stacked_barchart(
         df,
@@ -341,6 +370,7 @@ def update_tab_utci_summary_chart(
         hour,
         invert_month,
         invert_hour,
+        normalize,
         "UTCI thermal stress distribution",
     )
     custom_inputs = f"{var}"

--- a/my_project/template_graphs.py
+++ b/my_project/template_graphs.py
@@ -641,7 +641,7 @@ def thermal_stress_stacked_barchart(
             go.Bar(
                 x=x_data, y=y_data, name=categories[i], marker_color=colors[i],
                 hovertemplate=(
-                    "</b><br>Month: %{x}<br>Category: " + categories[i]+ "<br>Count: %{y:.1f}<br><extra></extra>" if len(normalize) == 0
+                    "</b><br>Month: %{x}<br>Category: " + categories[i] + "<br>Count: %{y}<br><extra></extra>" if len(normalize) == 0
                     else "</b><br>Month: %{x}<br>Category: " + categories[i] + "<br>Proportion: %{y:.1f}%<br><extra></extra>"
                 ),
             )
@@ -661,7 +661,7 @@ def thermal_stress_stacked_barchart(
         barmode="stack",
         dragmode=False,
         title=title,
-        margin=tight_margins,
+        margin=tight_margins.copy().update({"t": 55}),
     )
     if isNormalized:
         fig.update_layout(barnorm="percent")
@@ -834,3 +834,4 @@ def catch(func, handle=lambda e: e, *args, **kwargs):
         return func(*args, **kwargs)
     except Exception as e:
         return 0
+


### PR DESCRIPTION
# What I have done

- I added the switch, changing between proportion and count for thermal stress distribution
- I made the thermal stress distribution display the proportion and count data, SEPERATELY
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/a9436ccf-23e5-4fbd-b42d-e6d3554fa963)
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/e5941076-0b2a-4b4b-a1fd-8d0e7c50a5dc)


# What I have not done
- I have not been able to make the tooltips of thermal stress distribution display both % and count. 
- Its title looks bad on small screen 
<img width="1142" alt="image" src="https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/67b37ea1-3207-4aeb-97bb-291ab2ea08a3">


# Clarification requirement [Important]
Regarding the percentage display of the thermal stress distribution chart, I'm not sure which scenario that I need to implement.

Let consider a specific month (say Jan, doesn't really matter).

Initally, there are 10 categories with the counts like this: [10, 10, 10, ..., 10] **(in total 100)**. 
Then, I do an hour filter, and the counts change like this [3, 0, 1,..., 1] **(in total 10)**.

My question is: **WHAT IS THE DENOMINATOR?**

Two Scenarios:
1. Denominator of 10 (as it is implemented below): the stacked bar chart for the month will be 100%, because each category will be 30%, 0%, 10%,..., 10% respectively, adding up to 100%.
![image](https://github.com/CenterForTheBuiltEnvironment/clima/assets/35623720/c434ad3e-887d-4698-9c95-fe916787d7b3)
2. Denominator of 100: the stacked bar for the month will not be a 100%, because each category will be 3%, 0%..., 1% respectively. I need help for this.


