### PR TITLE
Update docs to reference main.py

### DIFF
--- a/docs/contributing/run-project-locally.md
+++ b/docs/contributing/run-project-locally.md
@@ -34,7 +34,7 @@ This guide is for Mac OSX, Linux, or Windows.
 
    Now you should be ready to run the tool locally.
 
-   `pipenv run python my_project.py`
+   `pipenv run python main.py`
 
 Visit [http://localhost:8080](http://localhost:8080) in your browser to check it out. Note that whenever you want to run the tool, you have to activate the virtualenv first.
 


### PR DESCRIPTION
The current directions give me an error:
```
$ pipenv run python my_project.py
/Users/chuck/.local/share/virtualenvs/clima-sybb1K6o/bin/python: can't open file '/Users/chuck/github/mccalluc/clima/my_project.py': [Errno 2] No such file or directory
```
Since `my_project` is now a directory, I just looked for other candidates at the top level, and `main.py` seems to work for me.
```
$ pipenv run python main.py

Dash is running on http://0.0.0.0:8080/

 * Serving Flask app 'app'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:8080
 * Running on http://10.0.0.30:8080
```
