### PR TITLE
Parse EPW as Latin-1, so that non-ASCII characters do not error

### DIFF
--- a/my_project/tab_select/app_select.py
+++ b/my_project/tab_select/app_select.py
@@ -163,7 +163,7 @@ def submitted_data(
         try:
             if "epw" in list_of_names[0]:
                 # Assume that the user uploaded a CSV file
-                lines = io.StringIO(decoded.decode("utf-8")).read().split("\n")
+                lines = io.StringIO(decoded.decode("latin-1")).read().split("\n")
                 df, location_info = create_df(lines, list_of_names[0])
                 return (
                     location_info,

--- a/my_project/tab_select/app_select.py
+++ b/my_project/tab_select/app_select.py
@@ -159,11 +159,15 @@ def submitted_data(
     ):
         content_type, content_string = list_of_contents[0].split(",")
 
-        decoded = base64.b64decode(content_string)
+        decoded_bytes = base64.b64decode(content_string)
         try:
             if "epw" in list_of_names[0]:
                 # Assume that the user uploaded a CSV file
-                lines = io.StringIO(decoded.decode("latin-1")).read().split("\n")
+                try:
+                    decoded_string = decoded_bytes.decode("utf-8")
+                except UnicodeDecodeError:
+                    decoded_string = decoded_bytes.decode("latin-1")
+                lines = decoded_string.split("\n")
                 df, location_info = create_df(lines, list_of_names[0])
                 return (
                     location_info,


### PR DESCRIPTION
- Fix #201

Locally, I've verified that the EPW in the original issue can now be loaded. I'm new here, so let me know if you need anything else.

I've done a little searching, but haven't found any discussion of what character encoding is correct for this file type. Another option -- not one I'd advise -- would be to try UTF-8 first, and if it fails, fall back to Latin-1