### PR TITLE
Add comfort envelope to psychrometric chart

### DIFF
--- a/my_project/tab_psy_chart/app_psy_chart.py
+++ b/my_project/tab_psy_chart/app_psy_chart.py
@@ -435,6 +435,18 @@ def update_psych_chart(
                 "extreme cold stress",
             ]
 
+        # Comfort envelope:
+        fig.add_trace(
+            go.Scatter(
+                # Approximate figure 5.3.1 from
+                # https://www.ashrae.org/file%20library/technical%20resources/standards%20and%20guidelines/standards%20addenda/55_2017_d_20200731.pdf
+                x=[f if si_ip == "ip" else (f - 32) / 1.8 for f in [71, 67, 75, 79]],
+                y=[0, 12, 12, 0],
+                fill="toself",
+                name="Comfort Envelope",
+            )
+        )
+
         fig.add_trace(
             go.Scatter(
                 x=df["DBT"],


### PR DESCRIPTION
The original issue drifts, but adding a comfort envelope is proposed in https://github.com/CenterForTheBuiltEnvironment/clima/issues/83#issuecomment-1322530903. There are a lot of choices here, and I'm not sure it's even a feature you want.

- What definition of the envelope would you want? 
- Would we want to show multiple? Allow the user to select between some choices?
- How should it be presented? This is just the default -- Lines and colors could change.
- Do we want anything in the legend?
<img width="365" alt="Screenshot 2023-12-02 at 9 20 44 PM" src="https://github.com/CenterForTheBuiltEnvironment/clima/assets/730388/be8c9417-38dd-40e9-af6b-3d56b0f3674c">

Filing as draft.

(Just noticed #116 as well -- There are a lot of possibilities, and, as noted there, this isn't the highest priority.) 