### PR TITLE
On "Sun and Clouds" tab, add legend and hide secondary box

### DIFF
--- a/my_project/tab_sun/charts_sun.py
+++ b/my_project/tab_sun/charts_sun.py
@@ -54,7 +54,7 @@ def monthly_solar(epw_df, si_ip):
                     + "</b><br>"
                     + "Month: %{customdata}<br>"
                     + "Hour: %{x}:00<br>"
-                    + "<extra></extra>" # Hides the "secondary box"
+                    + "<extra></extra>"  # Hides the "secondary box"
                 ),
             ),
             row=1,

--- a/my_project/tab_sun/charts_sun.py
+++ b/my_project/tab_sun/charts_sun.py
@@ -30,6 +30,9 @@ def monthly_solar(epw_df, si_ip):
     )
 
     for i in range(12):
+        # We only need legend entries for the first pair, since the others repeat.
+        is_first = i == 0
+
         fig.add_trace(
             go.Scatter(
                 x=g_h_rad_month_ave.loc[g_h_rad_month_ave["month"] == i + 1, "hour"],
@@ -40,8 +43,8 @@ def monthly_solar(epw_df, si_ip):
                 mode="lines",
                 line_color="orange",
                 line_width=2,
-                name=None,
-                showlegend=False,
+                name="Global",
+                showlegend=is_first,
                 customdata=epw_df.loc[epw_df["month"] == i + 1, "month_names"],
                 hovertemplate=(
                     "<b>"
@@ -51,6 +54,7 @@ def monthly_solar(epw_df, si_ip):
                     + "</b><br>"
                     + "Month: %{customdata}<br>"
                     + "Hour: %{x}:00<br>"
+                    + "<extra></extra>" # Hides the "secondary box"
                 ),
             ),
             row=1,
@@ -69,8 +73,8 @@ def monthly_solar(epw_df, si_ip):
                 mode="lines",
                 line_color="dodgerblue",
                 line_width=2,
-                name=None,
-                showlegend=False,
+                name="Diffuse",
+                showlegend=is_first,
                 customdata=epw_df.loc[epw_df["month"] == i + 1, "month_names"],
                 hovertemplate=(
                     "<b>"
@@ -80,6 +84,7 @@ def monthly_solar(epw_df, si_ip):
                     + "</b><br>"
                     + "Month: %{customdata}<br>"
                     + "Hour: %{x}:00<br>"
+                    + "<extra></extra>"  # Hides the "secondary box"
                 ),
             ),
             row=1,


### PR DESCRIPTION
- Fix #199

The `<extra>` tag is in the [hovertemplate docs](https://plotly.com/python/reference/scatter/#scatter-hovertemplate).

Screenshot with this fix:
<img width="294" alt="Screenshot 2023-12-07 at 10 14 26 PM" src="https://github.com/CenterForTheBuiltEnvironment/clima/assets/730388/2544381e-c4c2-4bb5-8f03-be39986a1ce0">

